### PR TITLE
Update WC_Form_Handler::save_account_details

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -233,6 +233,8 @@ class WC_Form_Handler {
 			wc_add_notice( __( 'Account details changed successfully.', 'woocommerce' ) );
 
 			do_action( 'woocommerce_save_account_details', $user->ID );
+			
+			do_action( 'password_reset', $user, $pass1 );
 
 			wp_safe_redirect( wc_get_page_permalink( 'myaccount' ) );
 			exit;


### PR DESCRIPTION
Update method save_account_details() from WC_Form_Handler, including the missing hook password_reset (https://developer.wordpress.org/reference/hooks/password_reset/).

The hook pass the user and the password altered by the user in plain text.

It's similar to what occurs on WC_Shortcode_My_Account::reset_password